### PR TITLE
[FEAT] Add prefix to MFEs

### DIFF
--- a/apps/app-shell/.eslintrc.json
+++ b/apps/app-shell/.eslintrc.json
@@ -21,7 +21,8 @@
     "prefer-destructuring": ["error", { "object": false, "array": false }],
     "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
     "import/extensions": 0,
-    "react/jsx-filename-extension": [2, { "extensions": [".js", ".jsx", ".ts", ".tsx"] }]
+    "react/jsx-filename-extension": [2, { "extensions": [".js", ".jsx", ".ts", ".tsx"] }],
+    "import/no-unresolved": [2, { "ignore": ["acme_*"] }]
   },
   "settings": {
     "import/resolver": {

--- a/apps/app-shell/src/App.tsx
+++ b/apps/app-shell/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
-const One = React.lazy(() => import('one/App'))
-const Two = React.lazy(() => import('two/App'))
+const One = React.lazy(() => import('acme_one/App'))
+const Two = React.lazy(() => import('acme_two/App'))
 
 const App = () => (
   <>

--- a/apps/app-shell/webpack.common.js
+++ b/apps/app-shell/webpack.common.js
@@ -12,8 +12,8 @@ module.exports = {
     new ModuleFederationPlugin({
       name: 'app-shell',
       remotes: {
-        one: 'one@http://localhost:8001/remoteEntry.js',
-        two: 'two@http://localhost:8002/remoteEntry.js',
+        acme_one: 'acme_one@http://localhost:8001/remoteEntry.js',
+        acme_two: 'acme_two@http://localhost:8002/remoteEntry.js',
       },
       shared: {
         ...deps,

--- a/apps/one/.eslintrc.json
+++ b/apps/one/.eslintrc.json
@@ -21,7 +21,8 @@
     "prefer-destructuring": ["error", { "object": false, "array": false }],
     "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
     "import/extensions": 0,
-    "react/jsx-filename-extension": [2, { "extensions": [".js", ".jsx", ".ts", ".tsx"] }]
+    "react/jsx-filename-extension": [2, { "extensions": [".js", ".jsx", ".ts", ".tsx"] }],
+    "import/no-unresolved": [2, { "ignore": ["acme_*"] }]
   },
   "settings": {
     "import/resolver": {

--- a/apps/one/federation.config.json
+++ b/apps/one/federation.config.json
@@ -1,5 +1,5 @@
 {
-  "name": "one",
+  "name": "acme_one",
   "exposes": {
     "./App": "./src/App"
   }

--- a/apps/one/package.json
+++ b/apps/one/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "one",
+  "name": "acme_one",
   "version": "1.0.0",
   "description": "",
   "private": true,

--- a/apps/one/webpack.common.js
+++ b/apps/one/webpack.common.js
@@ -12,7 +12,7 @@ module.exports = {
   plugins: [
     new ModuleFederationPlugin({
       ...federationConfig,
-      name: 'one',
+      name: 'acme_one',
       filename: 'remoteEntry.js',
       exposes: {
         './App': './src/App',

--- a/apps/one/webpack.dev.js
+++ b/apps/one/webpack.dev.js
@@ -20,7 +20,7 @@ module.exports = merge(common, {
   plugins: [
     new MFLiveReloadPlugin({
       port: 8001,
-      container: 'one',
+      container: 'acme_one',
       standalone: false,
     }),
   ],

--- a/apps/two/.eslintrc.json
+++ b/apps/two/.eslintrc.json
@@ -21,7 +21,8 @@
     "prefer-destructuring": ["error", { "object": false, "array": false }],
     "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
     "import/extensions": 0,
-    "react/jsx-filename-extension": [2, { "extensions": [".js", ".jsx", ".ts", ".tsx"] }]
+    "react/jsx-filename-extension": [2, { "extensions": [".js", ".jsx", ".ts", ".tsx"] }],
+    "import/no-unresolved": [2, { "ignore": ["acme_*"] }]
   },
   "settings": {
     "import/resolver": {

--- a/apps/two/federation.config.json
+++ b/apps/two/federation.config.json
@@ -1,5 +1,5 @@
 {
-  "name": "two",
+  "name": "acme_two",
   "exposes": {
     "./App": "./src/App"
   }

--- a/apps/two/package.json
+++ b/apps/two/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "two",
+  "name": "acme_two",
   "version": "1.0.0",
   "description": "",
   "private": true,

--- a/apps/two/webpack.common.js
+++ b/apps/two/webpack.common.js
@@ -12,7 +12,7 @@ module.exports = {
   plugins: [
     new ModuleFederationPlugin({
       ...federationConfig,
-      name: 'two',
+      name: 'acme_two',
       filename: 'remoteEntry.js',
       exposes: {
         './App': './src/App',

--- a/apps/two/webpack.dev.js
+++ b/apps/two/webpack.dev.js
@@ -20,7 +20,7 @@ module.exports = merge(common, {
   plugins: [
     new MFLiveReloadPlugin({
       port: 8002,
-      container: 'two',
+      container: 'acme_two',
       standalone: false,
     }),
   ],


### PR DESCRIPTION
With a prefix (ex: `acme_foo`) we can add an ignore pattern to the `import/no-unresolved` eslint rule. This enables us to bypass the error when running `yarn lint` in the `app_shell`, or any other part of the app where we used React.lazy imports.